### PR TITLE
Fix feel creation route

### DIFF
--- a/src/Feel/Update.elm
+++ b/src/Feel/Update.elm
@@ -16,7 +16,7 @@ gotoFeels =
 
 gotoNewFeel : Cmd Msg
 gotoNewFeel =
-    Navigation.newUrl "#feels/new"
+    Navigation.newUrl "#feel/new"
 
 
 gotoFeel : FeelId -> Cmd Msg


### PR DESCRIPTION
Not entirely sure why, but there was a mismatched between `gotoNewFeel` and Routes.elm, causing a 404 when clicking on the "Log a feel" button. This fixes it for me, but not certain if it is the right way to go. What do you say?